### PR TITLE
dashboard fix and route page titles add

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -1,21 +1,46 @@
 <div class="wrapper bg-white h-100" style="overflow-y: auto;">
-  <div class="container-fluid">
-    <div *ngIf="recentData">
+  <div class="p-0 m-0 d-flex flex-column">
+    <div *ngIf="recentData else loading" class="border rounded recent-pipelines-container mt-1">
+      <h5 class="card-title">Recent pipelines of OpenEBS</h5>
+      <table class="table table-borderless table-sm px-2 table-layout mx-1">
+        <thead>
+          <tr>
+            <th scope="col">Platform</th>
+            <th scope="col">PipelineID</th>
+            <th scope="col">Created at</th>
+            <th scope="col">Release Tag</th>
+            <th scope="col">Status</th>
+            <th scope="col">e2e Test</th>
+          </tr>
+        </thead>
+      </table>
       <div *ngFor="let recent of recentData.recent">
-        <div class="border w-100 my-3 rounded px-2">
+        <div class="border w-100 my-3 rounded px-2 mx-1">
           <div class="engine-title">{{getBranchName(recent.branch)}}</div>
           <div class="d-flex flex-column">
             <div>
               <table class="table table-borderless table-sm table-layout">
                 <tbody>
                   <tr *ngFor="let P of recent.pipelines">
-                    <td class="platform-icon"><img src="{{getImage(P.pipeline.project)}}" height="25px"
-                        alt="platform-icon" class="rounded-circle border"> {{getName(P.pipeline.project)}}</td>
+                    <td class="platform-icon">
+                      <div class="d-flex">
+                        <div><img src="{{getImage(P.pipeline.project)}}" height="25px" alt="platform-icon"
+                            class="rounded-circle border"></div>
+                        <div class="my-auto ml-1 btn btn-link btn-sm text-secondary" (click)="gotoEnginePage(P.pipeline.project,recent.branch)">{{getName(P.pipeline.project)}}</div>
+                      </div>
+                    </td>
+
                     <td><a type="button" class="btn btn-link btn-sm"
-                        routerLink="{{genDetailRouteLink(P.pipeline.id,P.pipeline.project,recent.branch)}}">{{P.pipeline.id}}</a></td>
+                        routerLink="{{genDetailRouteLink(P.pipeline.id,P.pipeline.project,recent.branch)}}">{{P.pipeline.id}}</a>
+                    </td>
                     <td>{{timeConverter(P.pipeline.created_at)}}</td>
-                    <td>{{P.pipeline.release_tag}}</td>
-                    <td>{{P.pipeline.status}}</td>
+                    <td class="text-center">
+                      <div class="text-size-16">{{P.pipeline.release_tag}}</div>
+                    </td>
+                    <td>
+                      <div class="px-2 badge text-capitalize" [ngClass]='genPipelineStatus(P.pipeline.status)'>
+                        {{P.pipeline.status}}</div>
+                    </td>
                     <td>
                       <app-doughnut-graph [pipeline]="P.pipeline"></app-doughnut-graph>
                     </td>
@@ -27,6 +52,26 @@
         </div>
       </div>
     </div>
+    <!-- <div class="border rounded infra-container mt-2">
+      <h5 class="card-title">Infrastructure Status</h5>
+      <div class="card m-2" style="width: 15rem;">
+        <div class="card-body">
+          <h5 class="card-title">GitLab</h5>
+          <h6 class="card-subtitle mb-2 text-muted">v11.11.1</h6>
+          <ul>
+            <li class="d-flux justify-content-around p-0">
+              <div>Status</div>
+              <div class="badge badge-pill">online</div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div> -->
   </div>
 </div>
 <router-outlet></router-outlet>
+<ng-template #loading>
+  <div class="text-center mx-auto">
+    <app-lodding-spinners></app-lodding-spinners>
+  </div>
+</ng-template>

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -1,21 +1,28 @@
-.table-layout{
-    table-layout: fixed;
-  }
-  table{
-    td{
-        vertical-align: middle;
-        font-size: 13px;
-    }
-    margin: 0px;
-    
-  }
-
-  .engine-title{
-    width: fit-content;
-    margin-top: -10px;
-    background-color: white;
-    border: 1px solid #dee2e6 ;
-    border-radius: 50px;
-    padding: 0px 10px;
+.table-layout {
+  table-layout: fixed;
+}
+table {
+  td {
+    vertical-align: middle;
     font-size: 13px;
   }
+  margin: 0px;
+}
+
+.engine-title {
+  width: fit-content;
+  margin-top: -10px;
+  background-color: white;
+  border: 1px solid #dee2e6;
+  border-radius: 50px;
+  padding: 0px 10px;
+  font-size: 13px;
+}
+.recent-pipelines-container {
+  // height: 60vh;
+  overflow: auto;
+}
+.text-size-16{
+  font-size: 15px;
+  // font-style: bold;
+}

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { DashboardData } from "../../services/ci-dashboard.service";
 import * as moment from 'moment';
-
+import { Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-dashboard',
@@ -10,13 +11,13 @@ import * as moment from 'moment';
 })
 export class DashboardComponent implements OnInit {
 
-  constructor(private ApiService: DashboardData) { }
+  constructor(private ApiService: DashboardData,private router: Router,private titleService: Title) {}
 
   public recentData: any = [];
 
 
   ngOnInit() {
-
+    this.titleService.setTitle('OpenEBS E2E Dashboard'); 
     this.ApiService.getAnyEndpointData("/recent").subscribe(res => {
       console.log(res);
       this.recentData = res
@@ -31,7 +32,7 @@ export class DashboardComponent implements OnInit {
       case "34":
         return "konvoy"
       case "43":
-        return "nativeK8s"
+        return "nativek8s"
       default:
         break;
     }
@@ -90,5 +91,35 @@ export class DashboardComponent implements OnInit {
         return 'Engine name not found'
     }
   }
+
+  genPipelineStatus(s: string) {
+    switch (s) {
+      case 'success':
+        return 'badge badge-pill badge-success'
+      case 'failed':
+        return 'badge badge-pill badge-danger'
+      case 'canceled':
+        return 'badge badge-pill badge-secondary'
+      case 'skipped':
+        return 'badge badge-pill badge-light'
+      case 'running':
+        return 'badge badge-pill badge-primary'
+      default:
+        return 'badge badge-pill badge-dark'
+    }
+  }
+
+  gotoEnginePage(project:string,branch:string){
+    let B = (b)=>{
+      if (b.includes('openebs')){
+        return b.replace('openebs-','')
+      }
+      else return b
+    }
+    let genPath = `/openebs/${B(branch)}/${this.getName(project)}`
+    this.router.navigate([genPath])
+
+  }
+
 
 }

--- a/src/app/components/dialog/dialog.component.ts
+++ b/src/app/components/dialog/dialog.component.ts
@@ -1,12 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { DashboardData } from "../../services/ci-dashboard.service";
-import { ISubscription } from "rxjs/Subscription";
-import { Subscription, Observable, timer, from, pipe } from "rxjs";
-import { isBoolean } from 'util';
 import * as moment from 'moment';
-import {ActivatedRoute, Router} from '@angular/router';
-
-
+import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-dialog',
@@ -18,7 +14,7 @@ export class DialogComponent implements OnInit {
 
   platform: any;
   branch: any;
-  constructor(private ApiService: DashboardData,private route: ActivatedRoute,private router: Router) { }
+  constructor(private ApiService: DashboardData, private route: ActivatedRoute, private router: Router, private titleService: Title) { }
 
   ngOnInit() {
     let url = window.location.pathname.split('/')
@@ -26,8 +22,8 @@ export class DialogComponent implements OnInit {
     this.platform = url[3]
     this.branch = url[2]
     let id = url[4]
-    console.log(`Platform : ${this.platform} \n Branch: ${this.branch} \n ID: ${id} \n\n`);
-
+    // console.log(`Platform : ${this.platform} \n Branch: ${this.branch} \n ID: ${id} \n\n`);
+    this.titleService.setTitle(`${id} | ${this.platform} | ${this.branch} of OpenEBS E2E pipeline`)
     this.getPipelineData(this.platform, this.branch, id)
   }
   public pipData: any;
@@ -45,25 +41,25 @@ export class DialogComponent implements OnInit {
   getPipelineData(platform: string, branch: string, id: string) {
     let B = this.genbranch(branch)
     // this.Data = timer(0, 10000000).subscribe(x => {
-      this.Data = this.ApiService.getPipelineData(platform, B, id).subscribe(res => {
-        this.pipData = res
-        this.pipData = this.pipData.pipeline;
-        this.sortData(this.pipData)
-        // if (!this.jobLogs) {
-        //   this.activeJob(this.platform, this.branch, this.pipData.jobs[0].id, this.pipData.jobs[0])
-        //   setTimeout(function () {
-        //     if (!this.jobLogs) {
-        //       this.activeJob(this.platform, this.branch, this.actJob)
-        //     }
-        //   }, 1000);
-        // }
+    this.Data = this.ApiService.getPipelineData(platform, B, id).subscribe(res => {
+      this.pipData = res
+      this.pipData = this.pipData.pipeline;
+      this.sortData(this.pipData)
+      // if (!this.jobLogs) {
+      //   this.activeJob(this.platform, this.branch, this.pipData.jobs[0].id, this.pipData.jobs[0])
+      //   setTimeout(function () {
+      //     if (!this.jobLogs) {
+      //       this.activeJob(this.platform, this.branch, this.actJob)
+      //     }
+      //   }, 1000);
+      // }
 
-      },
-        err => {
-          this.error = err
-          console.log(err);
-        }
-      )
+    },
+      err => {
+        this.error = err
+        console.log(err);
+      }
+    )
     // })
 
   }
@@ -121,7 +117,7 @@ export class DialogComponent implements OnInit {
 
     if (branch == 'cstor') {
       return 'openebs-cstor'
-    } else if (branch == 'release-branch' || branch == "lvm-localpv"|| branch == "jiva-operator") {
+    } else if (branch == 'release-branch' || branch == "lvm-localpv" || branch == "jiva-operator") {
       return branch
     } else {
       return `openebs-${branch}`
@@ -224,13 +220,13 @@ export class DialogComponent implements OnInit {
       return "_";
     }
   }
-  onClickClose(){
+  onClickClose() {
     let url = window.location.pathname.split('/')
-    if(url.includes('home')){
+    if (url.includes('home')) {
       console.log('redirect to home');
       this.router.navigate(['/home'])
-    }else{
-    this.router.navigate(['../'],{relativeTo:this.route})
+    } else {
+      this.router.navigate(['../'], { relativeTo: this.route })
     }
   }
 

--- a/src/app/components/doughnut-graph/doughnut-graph.component.html
+++ b/src/app/components/doughnut-graph/doughnut-graph.component.html
@@ -12,7 +12,7 @@
         <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff">
         </circle>
         <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
-          stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5">
+          stroke-width="6" stroke-dasharray="99 1" stroke-dashoffset="22.5">
         </circle>
         <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
           stroke-width="6" [attr.stroke-dasharray]="getJobPercentForPipeline(pipeline)" stroke-dashoffset="22.5">

--- a/src/app/components/doughnut-graph/doughnut-graph.component.ts
+++ b/src/app/components/doughnut-graph/doughnut-graph.component.ts
@@ -55,7 +55,7 @@ export class DoughnutGraphComponent implements OnInit {
   getJobPercentForPipeline(data) {
     try {
       if (data.status == "success") {
-        return "95 5";
+        return "99 1";
       }
       else if (data.status == "pending") {
         return "0 0";
@@ -67,7 +67,7 @@ export class DoughnutGraphComponent implements OnInit {
             count++;
           }
         }
-        var percentage = (count / data.jobs.length) * 100;
+        var percentage = (count / data.jobs.length) * 99;
         return `${percentage} ${100 - percentage}`
       }
       else if (data.status == "running") {

--- a/src/app/components/pipeline-table/pipeline-table.component.ts
+++ b/src/app/components/pipeline-table/pipeline-table.component.ts
@@ -2,10 +2,11 @@ import { Component, Input, OnInit } from '@angular/core';
 import {Router, ActivatedRoute, NavigationEnd, Params} from '@angular/router';
 import { DashboardData } from "../../services/ci-dashboard.service";
 import { ISubscription } from "rxjs/Subscription";
-import { Subscription, Observable, timer, from, pipe } from "rxjs";
+import { timer} from "rxjs";
+import { Title } from '@angular/platform-browser';
+
 
 import * as moment from 'moment';
-import * as dateformat from 'dateformat';
 
 @Component({
   selector: 'app-pipeline-table',
@@ -14,7 +15,7 @@ import * as dateformat from 'dateformat';
 })
 export class PipelineTableComponent implements OnInit {
   mySubscription: any;
-  constructor(private router: Router ,private ApiService: DashboardData,private activatedRoute: ActivatedRoute) {
+  constructor(private router: Router ,private ApiService: DashboardData,private activatedRoute: ActivatedRoute, private titleService:Title) {
     this.router.routeReuseStrategy.shouldReuseRoute = function () {
       return false;
     };
@@ -34,6 +35,7 @@ export class PipelineTableComponent implements OnInit {
     this.url = window.location.pathname.split('/')
     let branch:string = this.url[2]
     this.platform = this.url[3]
+    this.titleService.setTitle(`${this.platform} | ${branch} of OpenEBS E2E pipeline`)
     this.getPipeline(this.platform,branch)
     
   }

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -1,5 +1,5 @@
 <div class="wrapper sidebar-style ">
-  <div class="my-3 d-flex justify-content-around">
+  <a class="my-3 d-flex justify-content-around text-white" style="text-decoration: none" [routerLink]="['/home']">
     <div class="text-left">
       <img src="/assets/images/company-logos/openebs-stacked-color.png" alt="" class="p-0" height="70">
     </div>
@@ -7,7 +7,7 @@
       <div class="dashboard-title">CI Dashboard</div>
     </div>
     <div></div>
-  </div>
+  </a>
   <div class="row mx-auto">
     <ul class="list-group mx-auto w-100">
       <li class="px-0 sidebar-group px-4 py-3 active-sidebar-item">


### PR DESCRIPTION
PR includes below changes : 
### /home 

> pipeline status as a badge .
> All branches platform name as clickable and redirect to that engine pipelines page .

### sidebar-page:

> sidebar `ci dashboard` title as button and navigateTo `/home` page .

### Route/Page title:


> updated all route page with titles (example: /pipeline-detail page title will be `<ID> | <platform> | <branch> of  OpenEBS E2E pipelines`)


