### PR TITLE
Add `K8s version` column in /home pipeline table

### DIFF
--- a/src/app/common/check.ts
+++ b/src/app/common/check.ts
@@ -5,8 +5,8 @@ export class GlobalConstants {
     public static apiURL = function (mayastor?: boolean) {
         const host = window.location.origin;
         if (isDevMode()) {
-            // return mayastor ? 'https://localhost:8080' : 'https://localhost:3000'; //Uncomment while running localServer
-            return mayastor ? 'https://staging.openebs.ci/xray' : 'staging.openebs.ci/api';
+            return mayastor ? 'http://localhost:8080' : 'http://localhost:3000'; //Uncomment while running localServer
+            // return mayastor ? 'https://staging.openebs.ci/xray' : 'staging.openebs.ci/api';
         } else {
             return mayastor ? `${host}/xray` : `${host}/api`;
         }

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -10,9 +10,10 @@
           <tr>
             <th scope="col">{{'ROUTE.RECENT.TABLE.HEADER.PLATFORM' | translate}}</th>
             <th scope="col">{{'ROUTE.RECENT.TABLE.HEADER.PIPELINE-ID' | translate}}</th>
+            <th scope="col">{{'ROUTE.RECENT.TABLE.HEADER.K8SVERSION' | translate}}</th>
             <th scope="col">{{'ROUTE.RECENT.TABLE.HEADER.CREATED-AT' | translate}}</th>
-            <th scope="col">{{'ROUTE.RECENT.TABLE.HEADER.RELEASE-TAG' | translate}}</th>
-            <th scope="col">{{'ROUTE.RECENT.TABLE.HEADER.STATUS' | translate}}</th>
+            <th scope="col" class="text-center">{{'ROUTE.RECENT.TABLE.HEADER.RELEASE-TAG' | translate}}</th>
+            <th scope="col" class="text-center">{{'ROUTE.RECENT.TABLE.HEADER.STATUS' | translate}}</th>
           </tr>
         </thead>
       </table>
@@ -36,11 +37,12 @@
                     <td><a type="button" class="btn btn-link btn-sm"
                         routerLink="{{genDetailRouteLink(P.pipeline.id,P.pipeline.project,recent.branch)}}">{{P.pipeline.id}}</a>
                     </td>
+                    <td>{{validateValue(P.pipeline.k8s_version)}}</td>
                     <td>{{timeConverter(P.pipeline.created_at)}}</td>
                     <td>
-                      <div class="text-size-16 release-tag">{{P.pipeline.release_tag}}</div>
+                      <div class="text-size-16 text-center release-tag">{{validateValue(P.pipeline.release_tag)}}</div>
                     </td>
-                    <td>
+                    <td class="text-center">
                       <app-doughnut-graph [pipeline]="P.pipeline"></app-doughnut-graph>
                     </td>
                   </tr>

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -109,19 +109,19 @@ export class DashboardComponent implements OnInit {
   }
 
   gotoEnginePage(project: string, branch: string) {
-    let B = (b) => {
-      if (b.includes('openebs')) {
-        return b.replace('openebs-', '')
+    let genBranch = (branchName) => {
+      if (branchName.includes('openebs')) {
+        return branchName.replace('openebs-', '')
       }
-      else return b
+      else return branchName
     }
-    let genPath = `/openebs/${B(branch)}/${this.getName(project)}`
+    let genPath = `/openebs/${genBranch(branch)}/${this.getName(project)}`
     this.router.navigate([genPath])
 
   }
 
   validateValue(text: string) {
-    return text == 'NA' ? '_' : text;
+    return text === 'NA' ? '_' : text;
   }
 
 

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -11,13 +11,13 @@ import { Title } from '@angular/platform-browser';
 })
 export class DashboardComponent implements OnInit {
 
-  constructor(private ApiService: DashboardData,private router: Router,private titleService: Title) {}
+  constructor(private ApiService: DashboardData, private router: Router, private titleService: Title) { }
 
   public recentData: any = [];
 
 
   ngOnInit() {
-    this.titleService.setTitle('OpenEBS E2E Dashboard'); 
+    this.titleService.setTitle('OpenEBS E2E Dashboard');
     this.ApiService.getAnyEndpointData("/recent").subscribe(res => {
       this.recentData = res
 
@@ -108,16 +108,20 @@ export class DashboardComponent implements OnInit {
     }
   }
 
-  gotoEnginePage(project:string,branch:string){
-    let B = (b)=>{
-      if (b.includes('openebs')){
-        return b.replace('openebs-','')
+  gotoEnginePage(project: string, branch: string) {
+    let B = (b) => {
+      if (b.includes('openebs')) {
+        return b.replace('openebs-', '')
       }
       else return b
     }
     let genPath = `/openebs/${B(branch)}/${this.getName(project)}`
     this.router.navigate([genPath])
 
+  }
+
+  validateValue(text: string) {
+    return text == 'NA' ? '_' : text;
   }
 
 

--- a/src/assets/languages/default-en.json
+++ b/src/assets/languages/default-en.json
@@ -24,7 +24,8 @@
           "PIPELINE-ID":"PipelineID",
           "CREATED-AT":"Created at",
           "RELEASE-TAG":"Release Tag",
-          "STATUS":"Status"
+          "STATUS":"Status",
+          "K8SVERSION":"K8s versions"
         }
     }
   },


### PR DESCRIPTION
PR contains : 
- Added new column `k8s_version` for recent pipeline table in landing-page (/home )
- k8s version data present in `<server-url>/recent ` url
### Dashboard with k8sVerrsion column
<img width="1440" alt="Screenshot 2021-08-26 at 7 03 45 PM" src="https://user-images.githubusercontent.com/40464957/130972956-d46465dc-f6a5-44b1-967f-ea8dae8c36ca.png">

### Backend server data contained k8s_version in all pipelines 
<img width="1440" alt="Screenshot 2021-08-24 at 11 01 48 PM" src="https://user-images.githubusercontent.com/40464957/130972980-27524bd8-725e-4a36-ae75-b75fea76e168.png">
